### PR TITLE
License under the MIT license

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -9,6 +9,11 @@
 		-->
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPrivate" />
 	</rule>
+	<rule ref="MediaWiki.Commenting.ClassLevelLicense">
+		<properties>
+			<property name="license" value="MIT" />
+		</properties>
+	</rule>
 	<file>.</file>
 	<arg name="extensions" value="php"/>
 	<arg name="encoding" value="UTF-8"/>

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,19 @@
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/MinimalExample.alias.php
+++ b/MinimalExample.alias.php
@@ -2,6 +2,8 @@
 
 /**
  * Aliases for the MinimalExample extension
+ *
+ * @license MIT
  */
 
 $specialPageAliases = [];

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+	"license": "MIT",
 	"require": {
 		"league/commonmark": "2.4.2"
 	},

--- a/extension.json
+++ b/extension.json
@@ -4,6 +4,7 @@
 		"Daniel Scherzer"
 	],
 	"descriptionmsg": "minimalexample-desc",
+	"license-name": "MIT",
 	"type": "other",
 	"requires": {
 		"MediaWiki": ">= 1.39"

--- a/src/ApiDoesUserExist.php
+++ b/src/ApiDoesUserExist.php
@@ -8,6 +8,9 @@ use MediaWiki\User\UserFactory;
 use MediaWiki\User\UserIdentityLookup;
 use Wikimedia\ParamValidator\ParamValidator;
 
+/**
+ * @license MIT
+ */
 class ApiDoesUserExist extends ApiBase {
 
 	private UserFactory $userFactory;

--- a/src/Markdown/MWPreprocessedInline.php
+++ b/src/Markdown/MWPreprocessedInline.php
@@ -10,6 +10,8 @@ use League\CommonMark\Node\Inline\AbstractStringContainer;
  * since we trust the MediaWiki renderer. We need a subclass to target the
  * renderer in the environment configuration, but this does not have any
  * actual logic in it.
+ *
+ * @license MIT
  */
 class MWPreprocessedInline extends AbstractStringContainer {
 }

--- a/src/Markdown/MWPreprocessedRenderer.php
+++ b/src/Markdown/MWPreprocessedRenderer.php
@@ -11,6 +11,8 @@ use RuntimeException;
  * A renderer for `MWPreprocessedInline` nodes, where we actually did the
  * processing earlier and now just need to provide the raw HTML without it
  * getting escaped. There does not appear to be an existing renderer for this.
+ *
+ * @license MIT
  */
 class MWPreprocessedRenderer implements NodeRendererInterface {
 

--- a/src/Markdown/MarkdownContent.php
+++ b/src/Markdown/MarkdownContent.php
@@ -6,6 +6,8 @@ use TextContent;
 
 /**
  * Content that should be rendered according to markdown parsing.
+ *
+ * @license MIT
  */
 class MarkdownContent extends TextContent {
 

--- a/src/Markdown/MarkdownContentHandler.php
+++ b/src/Markdown/MarkdownContentHandler.php
@@ -23,6 +23,8 @@ use TitleFactory;
 
 /**
  * Content handler to add support for markdown.
+ *
+ * @license MIT
  */
 class MarkdownContentHandler extends TextContentHandler {
 

--- a/src/Markdown/MarkdownHooks.php
+++ b/src/Markdown/MarkdownHooks.php
@@ -5,6 +5,9 @@ namespace MediaWiki\Extension\MinimalExample\Markdown;
 use MediaWiki\Revision\Hook\ContentHandlerDefaultModelForHook;
 use Title;
 
+/**
+ * @license MIT
+ */
 class MarkdownHooks implements ContentHandlerDefaultModelForHook {
 
 	/**

--- a/src/ParserHooks.php
+++ b/src/ParserHooks.php
@@ -11,6 +11,9 @@ use Parser;
 use TitleFactory;
 use User;
 
+/**
+ * @license MIT
+ */
 class ParserHooks implements
 	GetPreferencesHook,
 	ParserFirstCallInitHook,

--- a/src/SpecialDoesUserExist.php
+++ b/src/SpecialDoesUserExist.php
@@ -7,6 +7,9 @@ use MediaWiki\User\UserFactory;
 use MediaWiki\User\UserIdentityLookup;
 use SpecialPage;
 
+/**
+ * @license MIT
+ */
 class SpecialDoesUserExist extends SpecialPage {
 
 	private UserFactory $userFactory;

--- a/src/SyntaxHelp/ApiGetSyntaxHelp.php
+++ b/src/SyntaxHelp/ApiGetSyntaxHelp.php
@@ -12,6 +12,8 @@ use Wikimedia\Rdbms\ILoadBalancer;
 
 /**
  * API module to retrieve the help page associated with a content model.
+ *
+ * @license MIT
  */
 class ApiGetSyntaxHelp extends ApiBase {
 

--- a/src/SyntaxHelp/DisplayHooks.php
+++ b/src/SyntaxHelp/DisplayHooks.php
@@ -6,6 +6,9 @@ use MediaWiki\Hook\BeforePageDisplayHook;
 use OutputPage;
 use Skin;
 
+/**
+ * @license MIT
+ */
 class DisplayHooks implements BeforePageDisplayHook {
 
 	/**

--- a/src/SyntaxHelp/SchemaHooks.php
+++ b/src/SyntaxHelp/SchemaHooks.php
@@ -5,6 +5,9 @@ namespace MediaWiki\Extension\MinimalExample\SyntaxHelp;
 use DatabaseUpdater;
 use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
 
+/**
+ * @license MIT
+ */
 class SchemaHooks implements LoadExtensionSchemaUpdatesHook {
 
 	/**

--- a/src/SyntaxHelp/SpecialConfigureSyntaxHelp.php
+++ b/src/SyntaxHelp/SpecialConfigureSyntaxHelp.php
@@ -14,6 +14,8 @@ use Wikimedia\Rdbms\ILoadBalancer;
  * Create a page that allows configuring where users can get help with syntax
  * for different content models. Stores the information in the custom table
  * `me_syntaxhelp` that this extension creates.
+ *
+ * @license MIT
  */
 class SpecialConfigureSyntaxHelp extends FormSpecialPage {
 

--- a/tests/phpunit/integration/ApiDoesUserExistTest.php
+++ b/tests/phpunit/integration/ApiDoesUserExistTest.php
@@ -11,6 +11,7 @@ use User;
  * @covers \MediaWiki\Extension\MinimalExample\ApiDoesUserExist
  * @group extension-MinimalExample
  * @group Database
+ * @license MIT
  */
 class ApiDoesUserExistTest extends ApiTestCase {
 	use MockAuthorityTrait;

--- a/tests/phpunit/integration/ParserHooksTest.php
+++ b/tests/phpunit/integration/ParserHooksTest.php
@@ -15,6 +15,7 @@ use Title;
  * @covers \MediaWiki\Extension\MinimalExample\ParserHooks
  * @group extension-MinimalExample
  * @group Database
+ * @license MIT
  */
 class ParserHooksTest extends MediaWikiIntegrationTestCase {
 	use MockAuthorityTrait;

--- a/tests/phpunit/integration/SpecialDoesUserExistTest.php
+++ b/tests/phpunit/integration/SpecialDoesUserExistTest.php
@@ -13,6 +13,7 @@ use User;
  * @covers \MediaWiki\Extension\MinimalExample\SpecialDoesUserExist
  * @group extension-MinimalExample
  * @group Database
+ * @license MIT
  */
 class SpecialDoesUserExistTest extends SpecialPageTestBase {
 	use MockAuthorityTrait;

--- a/tests/phpunit/unit/ParserHooksTest.php
+++ b/tests/phpunit/unit/ParserHooksTest.php
@@ -15,6 +15,7 @@ use User;
 /**
  * @covers \MediaWiki\Extension\MinimalExample\ParserHooks
  * @group extension-MinimalExample
+ * @license MIT
  */
 class ParserHooksTest extends MediaWikiUnitTestCase {
 


### PR DESCRIPTION
Add a `COPYING` file with the details, and use PHPCS to enforce that the license be documented in each file.