### PR TITLE
[WE-628] Drop REL1_39 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.4' ]
-        mediawiki: [ REL1_39 ]
+        php: [ '8.1' ]
+        mediawiki: [ REL1_43 ]
     steps:
       - name: Setup Extension
         uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: mbstring, intl
           coverage: none
           tools: composer, phpcs, phplint
@@ -56,12 +56,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mediawiki: [ REL1_39 ]
+        mediawiki: [ REL1_43 ]
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: mbstring, intl, ast
           coverage: none
           tools: composer
@@ -80,7 +80,7 @@ jobs:
           composer update
           composer update
       - name: Phan
-        run: ./vendor/bin/phan -d extensions/${{ env.EXTNAME }} --minimum-target-php-version=7.4 --long-progress-bar
+        run: ./vendor/bin/phan -d extensions/${{ env.EXTNAME }} --minimum-target-php-version=8.1 --long-progress-bar
 
   style-js:
     name: Code Style (JS+styles)

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
 		"league/commonmark": "2.8.2"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "38.0.0",
-		"mediawiki/mediawiki-phan-config": "0.12.1"
+		"mediawiki/mediawiki-codesniffer": "48.0.0 || 45.0.0 || 38.0.0",
+		"mediawiki/mediawiki-phan-config": "0.14.0 || 0.12.1"
 	},
 	"scripts": {
 		"test": [

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"license": "MIT",
 	"require": {
-		"league/commonmark": "2.8.2"
+		"league/commonmark": "^2.9.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "48.0.0 || 45.0.0 || 38.0.0",

--- a/extension.json
+++ b/extension.json
@@ -7,7 +7,7 @@
 	"license-name": "MIT",
 	"type": "other",
 	"requires": {
-		"MediaWiki": ">= 1.39"
+		"MediaWiki": ">= 1.43.0"
 	},
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\MinimalExample\\": "src/"


### PR DESCRIPTION
Drops REL1_39 from CI and raises the minimum MediaWiki version.

Closes out [WE-628](https://wikiteq.atlassian.net/browse/WE-628).

## Changes
- `.github/workflows/ci.yml`:
  - PHPUnit job matrix: `REL1_39` -> `REL1_43`, PHP `7.4` -> `8.1`
  - Static Analysis (Phan) job matrix: `REL1_39` -> `REL1_43`; setup PHP `7.4` -> `8.1`; Phan `--minimum-target-php-version` `7.4` -> `8.1`
  - Code Style (PHP) job: setup-php version `7.4` -> `8.1` (MediaWiki 1.43 requires PHP >= 8.1)
- `extension.json`: `"requires": { "MediaWiki": ">= 1.43.0" }` (was `>= 1.39`)

Per ticket scope, composer dev pins (`mediawiki/mediawiki-codesniffer` 38.0.0, `mediawiki/mediawiki-phan-config` 0.12.1), tests, and other files are intentionally untouched; CI runs will show whether those pins need follow-up bumps.

## Validation
- `ci.yml` parses via `yaml.safe_load`; matrices verified as `['REL1_43']` (PHPUnit + Phan) / `['8.1']` (PHP); no remaining `REL1_39` references
- `extension.json` parses via `json.load`; `requires.MediaWiki == ">= 1.43.0"`

Ticket: https://wikiteq.atlassian.net/browse/WE-628

[WE-628]: https://wikiteq.atlassian.net/browse/WE-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ