### PR TITLE
SLOP-211: bump league/commonmark to ^2.9.0 (CVE-2026-71488)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"license": "MIT",
 	"require": {
-		"league/commonmark": "2.8.2"
+		"league/commonmark": "^2.9.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "48.0.0 || 45.0.0 || 38.0.0",


### PR DESCRIPTION
## Summary
- Replaces the exact `league/commonmark` `2.8.2` pin with `^2.9.0` so installs resolve to versions patched against [GHSA-2q4p-g7hv-5rgv](https://github.com/thephpleague/commonmark/security/advisories/GHSA-2q4p-g7hv-5rgv) / CVE-2026-71488 (quadratic-time parse DoS, CVSS 7.5, affected `< 2.9.0`, fixed in `2.9.0`; current release `2.10.0` requires PHP `^7.4 || ^8.0`, compatible with this branch's MW 1.43/PHP 8.1 target).
- The repo has no `composer.lock`, so the vulnerable exact pin always resolved to 2.8.2; the constraint itself must exclude affected versions.
- Minimal one-line diff to `composer.json`.

## Context (Jira)
- Bug: SLOP-211 — filed for branches `WE-628` and `REL1_39` (the same pin also exists on `main` and is expected to be handled under the related MarkdownPages workstream, SLOP-206).

## Test plan
- [x] Constraint semantics verified: `^2.9.0` excludes 2.8.x, accepts 2.9.0/2.9.1/2.9.2/2.10.0
- [x] `composer.json` remains valid JSON with original tab indentation preserved
- [ ] CI green on this PR (PHPUnit under MW REL1_43 / PHP 8.1, phpcs, phan, JS lint)
- [ ] Markdown rendering spot-check: links/images/local-file rendering unchanged on commonmark 2.10.0

Work performed by AI / Cursor Agent under direction of Ike.